### PR TITLE
Update example to access the NI Digital session out of SDC

### DIFF
--- a/examples/dut_communication_using_semi_device_control_nidigital.py
+++ b/examples/dut_communication_using_semi_device_control_nidigital.py
@@ -44,7 +44,7 @@ try:
 
     # Get the resource name of the instrument session for NI 657x device.
     resource_name = semi_device_control.get_instrument_session("NI 657x").ResourceName
-    #Create an insecure gRPC channel to connect to the device server
+    # Create an insecure gRPC channel to connect to the device server
     device_server_channel = grpc.insecure_channel("localhost:31763")
     grpc_option = nidigital.GrpcSessionOptions(
         grpc_channel= device_server_channel,

--- a/examples/dut_communication_using_semi_device_control_nidigital.py
+++ b/examples/dut_communication_using_semi_device_control_nidigital.py
@@ -42,8 +42,10 @@ try:
     semi_device_control = SemiconductorDeviceControl(ISconfigpath)
     semi_device_control.start()
 
+    # Attach to the existing 657x gRPC session.
     # Get the resource name of the instrument session for NI 657x device.
     resource_name = semi_device_control.get_instrument_session("NI 657x").ResourceName
+    
     # Create an insecure gRPC channel to connect to the device server
     device_server_channel = grpc.insecure_channel("localhost:31763")
     grpc_option = nidigital.GrpcSessionOptions(
@@ -51,7 +53,7 @@ try:
         session_name=resource_name,
         initialization_behavior=nidigital.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION)
     
-    # Attach to nidigital grpc session
+    # get the existing 657x instrument session.
     nidigital_session = nidigital.Session(
         resource_name=resource_name,
         grpc_options=grpc_option)

--- a/examples/dut_communication_using_semi_device_control_nidigital.py
+++ b/examples/dut_communication_using_semi_device_control_nidigital.py
@@ -13,6 +13,7 @@ Instructions:.
 import os
 import sys
 import time
+import grpc
 
 import nidigital
 
@@ -41,9 +42,19 @@ try:
     semi_device_control = SemiconductorDeviceControl(ISconfigpath)
     semi_device_control.start()
 
-    # Get the 657x session
-    session_id = int(semi_device_control.get_instrument_session("NI 657x").SessionID)
-    nidigital_session = nidigital.Session.from_handle(session_id)
+    # Get the resource name of the instrument session for NI 657x device.
+    resource_name = semi_device_control.get_instrument_session("NI 657x").ResourceName
+    #Create an insecure gRPC channel to connect to the device server
+    device_server_channel = grpc.insecure_channel("localhost:31763")
+    grpc_option = nidigital.GrpcSessionOptions(
+        grpc_channel= device_server_channel,
+        session_name=resource_name,
+        initialization_behavior=nidigital.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION)
+    
+    # Attach to nidigital grpc session
+    nidigital_session = nidigital.Session(
+        resource_name=resource_name,
+        grpc_options=grpc_option)
 
     # Using the NI Digital DIO APIs to control Board/Device Pins
     pinset = nidigital_session.channels["3"]


### PR DESCRIPTION
### What does this Pull Request accomplish?

This Pull Request updates the `dut_communication_using_semi_device_control_nidigital.py` example to attach to the NI Digital gRPC session.

### Why should this Pull Request be merged?

Accessing the Instrument session using the instrument handle is not possible with the current implementation of the SDC gRPC session. This Pull Request updates the example to access the NI Digital session via the NI gRPC Device Server.

### What testing has been done?

Tested the change in simulation mode.
