### PR TITLE
Update Resource Name in grpc session options

### DIFF
--- a/examples/dut_communication_using_semi_device_control_nidigital.py
+++ b/examples/dut_communication_using_semi_device_control_nidigital.py
@@ -54,7 +54,7 @@ try:
     
     # get the existing 657x instrument session.
     nidigital_session = nidigital.Session(
-        resource_name = session_options.session_name,
+        resource_name = session_options.resource_name,
         grpc_options = grpc_option)
 
     # Using the NI Digital DIO APIs to control Board/Device Pins

--- a/nisdc/nisemidevicecontrol.py
+++ b/nisdc/nisemidevicecontrol.py
@@ -51,8 +51,9 @@ def generate_class_string(element_type, device_element_list):
     return class_content
 
 class GrpcSessionOptions:
-    def __init__(self, session_name, grpc_channel) :
+    def __init__(self, session_name, resource_name, grpc_channel) :
         self.session_name = session_name
+        self.resource_name = resource_name
         self.grpc_channel = grpc_channel
 
 class SemiconductorDeviceControl:
@@ -1187,7 +1188,7 @@ class SemiconductorDeviceControl:
         try:
             grpc_session_options = self.semidevicecontrol_session.GetGrpcSessionOptions(interface_name)
             device_server_channel = grpc.insecure_channel(grpc_session_options.Address + ":" + str(grpc_session_options.Port))
-            return GrpcSessionOptions(grpc_session_options.SessionName, device_server_channel)
+            return GrpcSessionOptions(grpc_session_options.SessionName, grpc_session_options.ResourceName, device_server_channel)
         
         except Exception as e:
             print("Exception occured at get grpc session options")


### PR DESCRIPTION
### What does this Pull Request accomplish?
This Pull Request adds a property called `resource_name` to the newly created API `get_grpc_session_options`  .

### Why should this Pull Request be merged?
This Pull Request updates the example to access the NI Digital session via the NI gRPC Device Server using the newly created API `get_grpc_session_options` along with the resource name.

### What testing has been done?
- Done manual testing.