### PR TITLE
Fix : Attach to Existing Session without Creating a new Session in the Constructor. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This library is dependent on Semiconductor Device Control addon for InstrumentSt
 38. Get Dynamic Protocol Settings
 39. Update Dynamic Protocol Settings
 40. Get Instrument Session **
-44. Get Session Options
+41. Get Session Options
 
 (** This API is deprecated from 2023 Q4 version of Semiconductor Device Control Addon.
 Refer to the [user manual](https://www.ni.com/documentation/en/semiconductor-device-control/latest/manual/manual-overview/) for more information.)

--- a/README.md
+++ b/README.md
@@ -8,62 +8,64 @@ This library is dependent on Semiconductor Device Control addon for InstrumentSt
 
 **Setup and cleanup functions**
 1. Instantiate - using IS configuration file  
-2. Destroy  
-3. Start  
-4. Stop  
+2. Attach to Existing Session
+3. Destroy  
+4. Start  
+5. Stop  
 
 **Hardware Read & Write to Register and Field** 
 
-5. Write Register by name (Device)  
-6. Read Register by name (Device)  
-7. Write Register by Address (Device)  
-8. Read Register by Address (Device)  
-9. Write Custom Register by Address (Device) 
-10. Read Custom Register by Address (Device) 
-11. Write Field by Name (Device)  
-12. Read Field by Name (Device)  
-13. Write Field by value definition (Device)  
+6. Write Register by name (Device)  
+7. Read Register by name (Device)  
+8. Write Register by Address (Device)  
+9. Read Register by Address (Device)  
+10. Write Custom Register by Address (Device) 
+11. Read Custom Register by Address (Device) 
+12. Write Field by Name (Device)  
+13. Read Field by Name (Device)  
+14. Write Field by value definition (Device)  
 
 **Hardware multiple Read & Write to Register and Field**
 
-14. Write Multiple Register by Name (Device)  
-15. Read Multiple Register by name (Device)  
-16. Write Multiple Register by Address (Device)  
-17. Read Multiple Register by Address (Device)  
-18. Write Multiple Fields by Name (Device)  
-19. Read Multiple Field by Name (Device)  
+15. Write Multiple Register by Name (Device)  
+16. Read Multiple Register by name (Device)  
+17. Write Multiple Register by Address (Device)  
+18. Read Multiple Register by Address (Device)  
+19. Write Multiple Fields by Name (Device)  
+20. Read Multiple Field by Name (Device)  
 
 **Cache Read & Write to Register and Field**
 
-20. Write Register by name (Cache)  
-21. Read Register by name (Cache)  
-22. Write Register by Address (Cache)  
-23. Read Register by Address (Cache)  
-24. Write Field by Name (Cache)  
-25. Read Field by Name (Cache)  
-26. Write Field by value definition (cache)  
-27. Write from Cache to Device  
-28. Clear Cache  
+21. Write Register by name (Cache)  
+22. Read Register by name (Cache)  
+23. Write Register by Address (Cache)  
+24. Read Register by Address (Cache)  
+25. Write Field by Name (Cache)  
+26. Read Field by Name (Cache)  
+27. Write Field by value definition (cache)  
+28. Write from Cache to Device  
+29. Clear Cache  
 
 **Cache multiple Read & Write to Register and Field**  
 
-29. Write Multiple Register by Name (Cache)  
-30. Read Multiple Register by name (Cache)  
-31. Write Multiple Register by Address (Cache)  
-32. Read Multiple Register by Address (Cache)  
-33. Write Multiple Fields by Name (Cache)  
-34. Read Multiple Field by Name (Cache) 
+30. Write Multiple Register by Name (Cache)  
+31. Read Multiple Register by name (Cache)  
+32. Write Multiple Register by Address (Cache)  
+33. Read Multiple Register by Address (Cache)  
+34. Write Multiple Fields by Name (Cache)  
+35. Read Multiple Field by Name (Cache) 
 
 **DIO operation**
 
-35. Write Pin State  
-36. Read Pin State 
+36. Write Pin State  
+37. Read Pin State 
 
 **Utils**
 
-37. Get Dynamic Protocol Settings
-38. Update Dynamic Protocol Settings
-39. Get Instrument Session **
+38. Get Dynamic Protocol Settings
+39. Update Dynamic Protocol Settings
+40. Get Instrument Session **
+44. Get Session Options
 
 (** This API is deprecated from 2023 Q4 version of Semiconductor Device Control Addon.
 Refer to the [user manual](https://www.ni.com/documentation/en/semiconductor-device-control/latest/manual/manual-overview/) for more information.)

--- a/nisdc/nisemidevicecontrol.py
+++ b/nisdc/nisemidevicecontrol.py
@@ -59,7 +59,7 @@ class GrpcSessionOptions:
 class SemiconductorDeviceControl:
     """This class is used for Instrument Studio export configuration."""
 
-    def __init__(self, isconfigpath):
+    def __init__(self, isconfigpath=None):
         """Create and return device control session using Instrument Studio export configuration.
 
         IS export configuration contains the register map and hardware configuration
@@ -73,9 +73,10 @@ class SemiconductorDeviceControl:
 
         try:
             self.semidevicecontrol_main = SemiDeviceControlMain()
-            self.semidevicecontrol_session = (
-                self.semidevicecontrol_main.CreateSemiDeviceControlSession(isconfigpath)
-            )
+            if isconfigpath:
+                self.semidevicecontrol_session = (
+                    self.semidevicecontrol_main.CreateSemiDeviceControlSession(isconfigpath)
+                )
 
         except Exception as e:
             print("Exception in accessing conf: {}".format(e))

--- a/nisdc/nisemidevicecontrol.py
+++ b/nisdc/nisemidevicecontrol.py
@@ -66,7 +66,7 @@ class SemiconductorDeviceControl:
         for Device Control.
 
         Args:
-            isconfigpath : the isconfig path.
+            isconfigpath : the isconfig path. if not specified, the device control session will not be created.
         """
         self.semidevicecontrol_main = None
         self.semidevicecontrol_session = None


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Make the constructor parameter optional.

### Why should this Pull Request be merged?

In the current implementation, a new SDC session is automatically initiated upon object creation, making the `attach_to_existing_session` API redundant. This PR makes the session creation optional in the constructor.

### What testing has been done?

Tested with the MeasurementLink sample measurement with SDC `attach_to_existing_session` API.
